### PR TITLE
Run test explicitly when building site.

### DIFF
--- a/perhost/vbox/Jenkinsfile-github-and-maven-deploy
+++ b/perhost/vbox/Jenkinsfile-github-and-maven-deploy
@@ -25,7 +25,7 @@ pipeline {
           withMaven(mavenSettingsConfig: 'github',
                     options: [junitPublisher(disabled: true,
                                              healthScaleFactor: 0.0)]) {
-            sh '$MVN_CMD -B clean site-deploy'
+            sh '$MVN_CMD -B clean test site-deploy'
 	  }
         }
       }


### PR DESCRIPTION
This is a requirement of the jacoco configuration (in parentpom).