### PR TITLE
Do not publish the jacoco report in Jenkins when building site.

### DIFF
--- a/perhost/vbox/Jenkinsfile-github-and-maven-deploy
+++ b/perhost/vbox/Jenkinsfile-github-and-maven-deploy
@@ -24,7 +24,8 @@ pipeline {
         retry(5) { // site-deploy fails sometimes
           withMaven(mavenSettingsConfig: 'github',
                     options: [junitPublisher(disabled: true,
-                                             healthScaleFactor: 0.0)]) {
+                                             healthScaleFactor: 0.0),
+                              jacocoPublisher(disabled: true)]) {
             sh '$MVN_CMD -B clean test site-deploy'
 	  }
         }


### PR DESCRIPTION
This is similar to not publishing the other reports.